### PR TITLE
fixed invalid key bug in binarize

### DIFF
--- a/trees/grammar.py
+++ b/trees/grammar.py
@@ -238,8 +238,10 @@ def binarize(grammar, **args):
                                       for label in vert])
                         rule_cnt = nf_vert_c[vert]
                     if 'reordering' in args:
-                        func, lin = args['reordering'](func, lin)
-                    binarize_rule(func, lin, rule_cnt, vert,
+                        _func, _lin = args['reordering'](func, lin)
+                    else:
+                        _func, _lin = func, lin
+                    binarize_rule(_func, _lin, rule_cnt, vert,
                                   label_gen, result)
     else:
         # without markovization


### PR DESCRIPTION
The reordering function potentially overwrites `func` and `lin`. Hence, these keys may no longer be valid in the next loop iteration. 
The problem occurred on `python2.7.13` when executing the following command:

```./treetools grammar tiger_tree_22.xml.txt the_output optimal --markov v:1 h:0 --dest-format rcg --src-format tigerxml```

[tiger_tree_22.xml.txt](https://github.com/wmaier/treetools/files/1010729/tiger_tree_22.xml.txt)

After the edit test cases passed for Python 2.7.13. (Test cases for python 3.6.1 did not pass even before the edit.)